### PR TITLE
Add Dynamsoft Barcode Reader REST API backend (v0.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "bytes-utils",
- "fastrand",
+ "fastrand 1.8.0",
  "http",
  "http-body",
  "tokio-stream",
@@ -369,7 +369,7 @@ dependencies = [
  "aws-smithy-http-tower",
  "aws-smithy-types 0.52.0",
  "bytes",
- "fastrand",
+ "fastrand 1.8.0",
  "http",
  "http-body",
  "hyper",
@@ -572,6 +572,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64-simd"
@@ -1026,6 +1032,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1085,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -1133,6 +1155,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1342,7 +1379,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "flate2",
  "nom 7.1.2",
@@ -1490,6 +1527,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1560,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1640,6 +1700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,7 +1713,7 @@ checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.6",
  "windows-sys 0.42.0",
 ]
 
@@ -1752,6 +1818,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -1933,6 +2005,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,10 +2190,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2549,6 +2676,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.11.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,11 +2750,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno 0.3.14",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2622,7 +2800,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2633,6 +2811,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-http 0.53.1",
+ "base64 0.21.7",
  "bytes",
  "clap",
  "console-subscriber",
@@ -2644,7 +2823,9 @@ dependencies = [
  "num_cpus",
  "opencv",
  "qrcode",
+ "reqwest",
  "rxing",
+ "serde_json",
  "sha2",
  "thiserror 1.0.38",
  "tokio",
@@ -2820,6 +3001,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +3182,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3220,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand 2.4.1",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"
@@ -3126,6 +3353,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,6 +3407,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3246,7 +3498,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3398,10 +3650,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3423,6 +3690,17 @@ checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
 dependencies = [
  "fnv",
  "lazy_static",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3502,6 +3780,18 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3760,6 +4050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3968,6 +4267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -555,15 +555,41 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c044c781163c001b913cd018fc95a628c50d0d2dfea8bca77dad71edb16e37"
+dependencies = [
+ "clang-sys",
+ "libc",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+]
 
 [[package]]
 name = "clap"
@@ -590,7 +616,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -758,6 +784,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +845,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -909,7 +947,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -951,7 +989,7 @@ dependencies = [
  "g2poly",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -994,6 +1032,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gif"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1052,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1285,6 +1341,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,9 +1391,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1447,7 +1513,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1505,6 +1571,39 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "opencv"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c607a407be5ff2484f55d2eb289bffd01de84f962779b8470e76f035dd3563d"
+dependencies = [
+ "cc",
+ "dunce",
+ "jobserver",
+ "libc",
+ "num-traits",
+ "opencv-binding-generator",
+ "pkg-config",
+ "semver",
+ "shlex",
+ "vcpkg",
+ "windows",
+]
+
+[[package]]
+name = "opencv-binding-generator"
+version = "0.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833f00c6deee8dd615249af42fa35ff030c5c73ee3c13e44baf1135a4d57af86"
+dependencies = [
+ "clang",
+ "clang-sys",
+ "dunce",
+ "percent-encoding",
+ "regex",
+ "shlex",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1570,7 +1669,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1584,6 +1683,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1612,7 +1717,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -1629,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1656,7 +1761,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1670,13 +1775,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.23"
+name = "qrcode"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "166f136dfdb199f98186f3649cf7a0536534a61417a1a30221b492b4fb60ce3f"
+dependencies = [
+ "image",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1705,7 +1825,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1849,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "rustslinger"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -1864,6 +1984,8 @@ dependencies = [
  "image",
  "kamadak-exif",
  "num_cpus",
+ "opencv",
+ "qrcode",
  "rqrr",
  "sha2",
  "thiserror",
@@ -1962,7 +2084,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2006,6 +2128,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2089,6 +2217,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,7 +2259,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2217,7 +2356,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2360,7 +2499,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2435,6 +2574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,7 +2631,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2499,7 +2653,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2577,6 +2731,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,6 +2881,15 @@ dependencies = [
  "windows_x86_64_gnu 0.48.5",
  "windows_x86_64_gnullvm 0.48.5",
  "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2741,6 +3005,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,29 +3,58 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.8.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -33,6 +62,38 @@ name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-stream"
@@ -71,6 +132,29 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "aws-config"
@@ -445,7 +529,7 @@ checksum = "1304eab461cf02bd70b083ed8273388f9724c549b316ba3d1e213ce0e9e7fb7e"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -499,6 +583,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +610,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +629,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
@@ -536,6 +653,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -566,10 +689,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
 
 [[package]]
 name = "clang"
@@ -597,7 +751,7 @@ version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -612,7 +766,7 @@ version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -626,6 +780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "codepage-437"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40c1169585d8d08e5675a39f2fc056cd19a258fc4cba5e3bbf4a9c1026de535"
+dependencies = [
+ "csv",
 ]
 
 [[package]]
@@ -773,6 +936,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +978,35 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "equivalent"
@@ -832,9 +1045,20 @@ dependencies = [
  "flume",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "smallvec",
  "threadpool",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -847,6 +1071,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,12 +1107,12 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -981,34 +1234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "g2gen"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3739628484df50bec1e86ffbe43015f90f66cd4b277d66ba9988090e69ff14"
-dependencies = [
- "g2poly",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "g2p"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa69b481acf54821c3a4034c5208a0a886276a21d9853d99a3180f96760614d"
-dependencies = [
- "g2gen",
- "g2poly",
-]
-
-[[package]]
-name = "g2poly"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bd7328d5d3216889d176c218d991c0fd848d1ffe1c81d96faf1a742db38212"
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1279,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,7 +1306,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1080,11 +1315,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.2.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c467d36af040b7b2681f5fddd27427f6da8d3d072f575a265e181d2f8e8d157"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1095,18 +1332,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hdrhistogram"
@@ -1117,7 +1345,7 @@ dependencies = [
  "base64",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.1.2",
  "num-traits",
 ]
 
@@ -1126,6 +1354,12 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1256,6 +1490,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core 0.52.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "image"
 version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,14 +1522,72 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.11.4",
  "jpeg-decoder",
  "num-rational",
  "num-traits",
- "png",
+ "png 0.17.7",
  "scoped_threadpool",
- "tiff",
+ "tiff 0.8.1",
 ]
+
+[[package]]
+name = "image"
+version = "0.25.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif 0.13.3",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff 0.10.3",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imageproc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2393fb7808960751a52e8a154f67e7dd3f8a2ef9bd80d1553078a7b4e8ed3f0d"
+dependencies = [
+ "ab_glyph",
+ "approx",
+ "getrandom 0.2.8",
+ "image 0.25.8",
+ "itertools 0.12.1",
+ "nalgebra",
+ "num",
+ "rand",
+ "rand_distr",
+ "rayon",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
@@ -1286,12 +1601,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1301,6 +1616,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1335,6 +1661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,10 +1696,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1396,6 +1732,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,12 +1773,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.9.0"
+name = "loop9"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
- "hashbrown 0.13.1",
+ "imgref",
 ]
 
 [[package]]
@@ -1435,7 +1787,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1443,6 +1795,26 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -1455,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -1490,6 +1862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,10 +1884,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "mutate_once"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
+
+[[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
 
 [[package]]
 name = "nanorand"
@@ -1517,6 +1933,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nom"
 version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1946,66 @@ checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1537,10 +2019,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.1"
+name = "num-iter"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1548,12 +2030,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.15"
+name = "num-rational"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1568,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opencv"
@@ -1624,6 +2119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,10 +2151,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1696,10 +2224,23 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -1742,6 +2283,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,7 +2318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.107",
@@ -1775,13 +2335,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "qrcode"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "166f136dfdb199f98186f3649cf7a0536534a61417a1a30221b492b4fb60ce3f"
 dependencies = [
- "image",
+ "image 0.24.5",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1829,10 +2410,76 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.6.1"
+name = "rand_distr"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "system-deps",
+ "thiserror 1.0.38",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1840,14 +2487,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -1856,18 +2501,19 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1876,7 +2522,18 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.28",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1884,6 +2541,18 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -1901,17 +2570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rqrr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8b87d1f9f69bb1a6c77e20fd303f9617b2b68dcff87cd9bcbfff2ced4b8a0b"
-dependencies = [
- "g2p",
- "image",
- "lru",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,7 +2584,7 @@ version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1981,14 +2639,14 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
- "image",
+ "image 0.24.5",
  "kamadak-exif",
  "num_cpus",
  "opencv",
  "qrcode",
- "rqrr",
+ "rxing",
  "sha2",
- "thiserror",
+ "thiserror 1.0.38",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2001,10 +2659,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
+name = "rxing"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4fcbbc6ac324d7018be17d2c94c6c4690ca2f95b9345ffbc001fe8e459ebeb"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "codepage-437",
+ "encoding_rs",
+ "fancy-regex",
+ "image 0.25.8",
+ "imageproc",
+ "multimap",
+ "num",
+ "once_cell",
+ "regex",
+ "rxing-one-d-proc-derive",
+ "serde",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "uriparse",
+ "urlencoding",
+]
+
+[[package]]
+name = "rxing-one-d-proc-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7e5f136594d614d0d8e44f63508abd25c8fe0280655bb1d477b177bf718d0a4"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "schannel"
@@ -2044,7 +2746,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2069,22 +2771,32 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2095,6 +2807,15 @@ checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -2145,6 +2866,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-abstraction"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2886,27 @@ checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
  "outref",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2234,6 +2989,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,7 +3022,16 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.38",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2260,6 +3043,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2289,6 +3083,20 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2396,6 +3204,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,7 +3295,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2544,6 +3386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,16 +3404,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
+
+[[package]]
 name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2578,6 +3453,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -2612,34 +3493,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
-dependencies = [
- "bumpalo",
- "log",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2647,22 +3516,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2695,9 +3567,19 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.7"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "winapi"
@@ -2737,7 +3619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -2748,7 +3630,16 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2770,7 +3661,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
 ]
@@ -2809,7 +3700,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
 ]
 
@@ -2865,7 +3756,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2881,6 +3772,22 @@ dependencies = [
  "windows_x86_64_gnu 0.48.5",
  "windows_x86_64_gnullvm 0.48.5",
  "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2905,6 +3812,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,6 +3834,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2941,6 +3860,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3888,12 @@ name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2977,6 +3914,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3930,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3007,6 +3956,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,7 +3983,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ license = "MIT OR Apache-2.0"
 # Build with: cargo build --features wechat
 wechat = ["dep:opencv"]
 
+# Enable Dynamsoft Barcode Reader via its REST API (requires a running DBR service + license).
+# Build with: cargo build --features dynamsoft
+dynamsoft = ["dep:reqwest", "dep:serde_json", "dep:base64"]
+
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.11"
@@ -35,6 +39,9 @@ hex = "0.4"
 tracing = "0.1"
 console-subscriber = "0.1.8"
 opencv = { version = "0.98", optional = true }
+reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
+serde_json = { version = "1", optional = true }
+base64 = { version = "0.21", optional = true }
 
 [dev-dependencies]
 qrcode = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustslinger"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Thomas Kessler <tom@rkessler.group>"]
 description = "rustslinger is a tool for scanning and analysing large image data sets stored on AWS S3 buckets."
@@ -8,6 +8,11 @@ license = "MIT OR Apache-2.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+# Enable OpenCV wechat_qrcode detector (requires OpenCV 4.x with contrib installed).
+# Build with: cargo build --features wechat
+wechat = ["dep:opencv"]
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -19,7 +24,7 @@ aws-smithy-http = "0.53.0"
 sha2 = "0.10"
 hex-literal = "0.3.4"
 bytes = "1.3.0"
-image = "0.24.5" 
+image = "0.24.5"
 rqrr = "0.6.0"
 num_cpus = "1.15.0"
 kamadak-exif = "0.5.5"
@@ -29,6 +34,10 @@ anyhow = {version ="1"}
 hex = "0.4"
 tracing = "0.1"
 console-subscriber = "0.1.8"
+opencv = { version = "0.98", optional = true }
+
+[dev-dependencies]
+qrcode = "0.13"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ sha2 = "0.10"
 hex-literal = "0.3.4"
 bytes = "1.3.0"
 image = "0.24.5"
-rqrr = "0.6.0"
+rxing = "0.8"
 num_cpus = "1.15.0"
 kamadak-exif = "0.5.5"
 clap = {version = "4.0.32", features =["derive"]}

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ rustslinger is a tool for scanning and analysing large image data sets stored in
 Usage: rustslinger [OPTIONS] --bucket <BUCKET>
 
 Options:
-  -b, --bucket <BUCKET>    aws s3 bucket
-  -p, --prefix <PREFIX>    aws s3 prefix
-  -f, --profile <PROFILE>  aws s3 profile
-  -l, --bucketlist         aws s3 bucket list
-  -h, --help               Print help information
-  -V, --version            Print version information
+  -b, --bucket <BUCKET>        aws s3 bucket
+  -p, --prefix <PREFIX>        aws s3 prefix
+  -f, --profile <PROFILE>      aws s3 profile
+  -l, --bucketlist             aws s3 bucket list
+  -m, --model-path <PATH>      path to wechat_qrcode model files directory
+  -h, --help                   Print help information
+  -V, --version                Print version information
 ```
 
 ## Why?
@@ -30,7 +31,7 @@ Key concepts and technologies used to develop **rustslinger** include:
 
 - Concurrency & Multithreading with async/await and threadpools using [futures](https://crates.io/crates/futures) and [tokio](https://crates.io/crates/tokio)
 - AWS Rust SDK using [aws-sdk-s3](https://crates.io/crates/aws-sdk-s3) and [aws-config](https://crates.io/crates/aws-config)
-- QR Code Scanning using [rqrr](https://crates.io/crates/rqrr) and [image](https://crates.io/crates/image)
+- QR Code Scanning using [rqrr](https://crates.io/crates/rqrr) and [image](https://crates.io/crates/image), or optionally [OpenCV wechat_qrcode](https://docs.opencv.org/4.x/d5/d04/classcv_1_1wechat__qrcode_1_1WeChatQRCode.html)
 - EXIF Metadata Extraction using [kamadak-exif](https://crates.io/crates/kamadak-exif)
 - Structured Error Handling using [thiserror](https://crates.io/crates/thiserror) and [anyhow](https://crates.io/crates/anyhow)
 - Structured Diagnostic Logging using [tracing](https://crates.io/crates/tracing)
@@ -46,7 +47,7 @@ Key concepts and technologies used to develop **rustslinger** include:
 
 2. **Analyse** — as each download completes, the download permit is released and a CPU-bound analysis task is spawned on a blocking thread pool (throttled separately to `num_cpus` permits). Each image is analysed for:
    - **SHA-256 hash** of the raw bytes
-   - **QR codes** via `rqrr` — the image is decoded, resized to 800×600, and scanned for QR grids
+   - **QR codes** — via `rqrr` by default, or `wechat_qrcode` when built with `--features wechat`
    - **EXIF `UserComment`** field via `kamadak-exif` — extracted independently of QR results
 
 3. **Output** — results are streamed back to the main thread via an unbounded channel and printed as CSV-style rows:
@@ -56,6 +57,38 @@ index, key, hash, qr_code, qr_quality, qr_source
 ```
 
 Each image can produce multiple result rows — one per QR code found, plus one if an EXIF `UserComment` is present.
+
+## QR Code Backends
+
+### Default — rqrr (pure Rust, no extra dependencies)
+
+```bash
+cargo build --release
+```
+
+### Optional — OpenCV wechat_qrcode (better detection on real-world images)
+
+The OpenCV backend handles rotated, blurry, low-contrast, and partially occluded QR codes that `rqrr` cannot decode. It requires OpenCV 4.x with contrib modules installed.
+
+**macOS:**
+```bash
+brew install opencv
+cargo build --release --features wechat
+```
+
+**With CNN model files (best quality):**
+
+Download the four model files from the [OpenCV contrib test data repository](https://github.com/opencv/opencv_contrib/tree/master/modules/wechat_qrcode/src/zxing/qrcode):
+- `detect.prototxt` + `detect.caffemodel`
+- `sr.prototxt` + `sr.caffemodel`
+
+Then pass the directory at runtime:
+
+```bash
+rustslinger --bucket my-bucket --model-path /path/to/models
+```
+
+Without `--model-path`, the wechat backend uses its built-in lightweight detector automatically.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Options:
   -f, --profile <PROFILE>      aws s3 profile
   -l, --bucketlist             aws s3 bucket list
   -m, --model-path <PATH>      path to wechat_qrcode model files directory
+      --dynamsoft-license      Dynamsoft Barcode Reader license key (--features dynamsoft)
+      --dynamsoft-endpoint     Dynamsoft REST API endpoint URL (--features dynamsoft)
+      --dynamsoft-only         use Dynamsoft only — skip rxing and wechat (--features dynamsoft)
   -h, --help                   Print help information
   -V, --version                Print version information
 ```
@@ -31,7 +34,7 @@ Key concepts and technologies used to develop **rustslinger** include:
 
 - Concurrency & Multithreading with async/await and threadpools using [futures](https://crates.io/crates/futures) and [tokio](https://crates.io/crates/tokio)
 - AWS Rust SDK using [aws-sdk-s3](https://crates.io/crates/aws-sdk-s3) and [aws-config](https://crates.io/crates/aws-config)
-- QR Code Scanning using [rxing](https://crates.io/crates/rxing) (pure-Rust ZXing port) and [image](https://crates.io/crates/image), with optional [OpenCV wechat_qrcode](https://docs.opencv.org/4.x/d5/d04/classcv_1_1wechat__qrcode_1_1WeChatQRCode.html) as a second-pass backend
+- QR Code Scanning using [rxing](https://crates.io/crates/rxing) (pure-Rust ZXing port) and [image](https://crates.io/crates/image), with optional [OpenCV wechat_qrcode](https://docs.opencv.org/4.x/d5/d04/classcv_1_1wechat__qrcode_1_1WeChatQRCode.html) as a second-pass backend and optional [Dynamsoft Barcode Reader](https://www.dynamsoft.com/barcode-reader/overview/) REST API as a third-pass backend
 - EXIF Metadata Extraction using [kamadak-exif](https://crates.io/crates/kamadak-exif)
 - Structured Error Handling using [thiserror](https://crates.io/crates/thiserror) and [anyhow](https://crates.io/crates/anyhow)
 - Structured Diagnostic Logging using [tracing](https://crates.io/crates/tracing)
@@ -45,10 +48,10 @@ Key concepts and technologies used to develop **rustslinger** include:
 
 1. **Download** — paginates through all objects in the target S3 bucket and downloads them concurrently, throttled by a semaphore (`num_cpus × 10` permits) to avoid overwhelming the network or the AWS API.
 
-2. **Analyse** — as each download completes, the download permit is released and a CPU-bound analysis task is spawned on a blocking thread pool (throttled separately to `num_cpus` permits). Each image is analysed for:
+2. **Analyse** — as each download completes, the download permit is released and a CPU-bound analysis task is spawned on a blocking thread pool (throttled separately to `num_cpus` permits). Each image is analysed in this order:
    - **SHA-256 hash** of the raw bytes
-   - **QR codes** — via `rxing` (always), plus `wechat_qrcode` as a second pass when built with `--features wechat`; results are deduplicated by content across both backends
-   - **EXIF `UserComment`** field via `kamadak-exif` — extracted independently of QR results
+   - **EXIF `UserComment`** field via `kamadak-exif` — extracted first, independently of QR results
+   - **QR codes** — via `rxing` (always), plus `wechat_qrcode` as a second pass when built with `--features wechat`, and optionally Dynamsoft Barcode Reader REST API as a third pass when built with `--features dynamsoft`; all results are deduplicated by content across backends
 
 3. **Output** — results are streamed back to the main thread via an unbounded channel and printed as CSV-style rows:
 
@@ -56,7 +59,7 @@ Key concepts and technologies used to develop **rustslinger** include:
 index, key, hash, qr_code, qr_quality, qr_source
 ```
 
-Each image can produce multiple result rows — one per QR code found, plus one if an EXIF `UserComment` is present.
+Each image can produce multiple result rows — one per QR code found, plus one if an EXIF `UserComment` is present. The `qr_source` field identifies which backend found the code: `rxing`, `wechat_qrcode`, `dynamsoft`, or `EXIFUserComment`.
 
 ## QR Code Backends
 
@@ -91,6 +94,33 @@ rustslinger --bucket my-bucket --model-path /path/to/models
 ```
 
 Without `--model-path`, the wechat backend uses its built-in lightweight detector automatically.
+
+### Optional — Dynamsoft Barcode Reader (REST API, third-pass backend)
+
+When built with `--features dynamsoft`, **rustslinger** can call a Dynamsoft Barcode Reader service via its REST API. Dynamsoft is particularly effective on damaged, low-resolution, or unusual barcode formats. It runs as a third pass after rxing and wechat, contributing any codes not already found. All results are merged and deduplicated by content.
+
+Requires a running [Dynamsoft Barcode Reader](https://www.dynamsoft.com/barcode-reader/overview/) service instance and a valid license key.
+
+```bash
+cargo build --release --features dynamsoft
+```
+
+**Third-pass (after rxing + wechat):**
+
+```bash
+rustslinger --bucket my-bucket \
+  --dynamsoft-license YOUR_LICENSE \
+  --dynamsoft-endpoint http://localhost:18622/api/dbr/read
+```
+
+**Dynamsoft only (skip rxing and wechat):**
+
+```bash
+rustslinger --bucket my-bucket \
+  --dynamsoft-license YOUR_LICENSE \
+  --dynamsoft-endpoint http://localhost:18622/api/dbr/read \
+  --dynamsoft-only
+```
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Key concepts and technologies used to develop **rustslinger** include:
 
 - Concurrency & Multithreading with async/await and threadpools using [futures](https://crates.io/crates/futures) and [tokio](https://crates.io/crates/tokio)
 - AWS Rust SDK using [aws-sdk-s3](https://crates.io/crates/aws-sdk-s3) and [aws-config](https://crates.io/crates/aws-config)
-- QR Code Scanning using [rqrr](https://crates.io/crates/rqrr) and [image](https://crates.io/crates/image), or optionally [OpenCV wechat_qrcode](https://docs.opencv.org/4.x/d5/d04/classcv_1_1wechat__qrcode_1_1WeChatQRCode.html)
+- QR Code Scanning using [rxing](https://crates.io/crates/rxing) (pure-Rust ZXing port) and [image](https://crates.io/crates/image), with optional [OpenCV wechat_qrcode](https://docs.opencv.org/4.x/d5/d04/classcv_1_1wechat__qrcode_1_1WeChatQRCode.html) as a second-pass backend
 - EXIF Metadata Extraction using [kamadak-exif](https://crates.io/crates/kamadak-exif)
 - Structured Error Handling using [thiserror](https://crates.io/crates/thiserror) and [anyhow](https://crates.io/crates/anyhow)
 - Structured Diagnostic Logging using [tracing](https://crates.io/crates/tracing)
@@ -47,7 +47,7 @@ Key concepts and technologies used to develop **rustslinger** include:
 
 2. **Analyse** — as each download completes, the download permit is released and a CPU-bound analysis task is spawned on a blocking thread pool (throttled separately to `num_cpus` permits). Each image is analysed for:
    - **SHA-256 hash** of the raw bytes
-   - **QR codes** — via `rqrr` by default, or `wechat_qrcode` when built with `--features wechat`
+   - **QR codes** — via `rxing` (always), plus `wechat_qrcode` as a second pass when built with `--features wechat`; results are deduplicated by content across both backends
    - **EXIF `UserComment`** field via `kamadak-exif` — extracted independently of QR results
 
 3. **Output** — results are streamed back to the main thread via an unbounded channel and printed as CSV-style rows:
@@ -60,15 +60,17 @@ Each image can produce multiple result rows — one per QR code found, plus one 
 
 ## QR Code Backends
 
-### Default — rqrr (pure Rust, no extra dependencies)
+### Default — rxing (pure Rust, no extra dependencies)
+
+`rxing` is a pure-Rust port of ZXing with native multi-code support. It runs on every build with `TryHarder` enabled to maximise detection coverage.
 
 ```bash
 cargo build --release
 ```
 
-### Optional — OpenCV wechat_qrcode (better detection on real-world images)
+### Optional — OpenCV wechat_qrcode (second-pass backend)
 
-The OpenCV backend handles rotated, blurry, low-contrast, and partially occluded QR codes that `rqrr` cannot decode. It requires OpenCV 4.x with contrib modules installed.
+When built with `--features wechat`, `wechat_qrcode` runs after `rxing` and contributes any QR codes not already found — particularly useful for rotated, blurry, low-contrast, or partially occluded codes. Results from both backends are merged and deduplicated by content. It requires OpenCV 4.x with contrib modules installed.
 
 **macOS:**
 ```bash

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -10,6 +10,21 @@ use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+// ---------------------------------------------------------------------------
+// AnalyticsConfig — shared, immutable configuration for every analysis task
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+pub struct AnalyticsConfig {
+    pub model_path: Option<PathBuf>,
+    #[cfg(feature = "dynamsoft")]
+    pub dynamsoft_license: Option<String>,
+    #[cfg(feature = "dynamsoft")]
+    pub dynamsoft_endpoint: Option<String>,
+    #[cfg(feature = "dynamsoft")]
+    pub dynamsoft_only: bool,
+}
+
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
@@ -186,6 +201,105 @@ fn scan_qr_wechat(
 }
 
 // ---------------------------------------------------------------------------
+// Dynamsoft backend — REST API, compiled in with --features dynamsoft
+// Runs after rxing + wechat (or alone when dynamsoft_only = true).
+// Requires a running Dynamsoft Barcode Reader service and a valid license.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "dynamsoft")]
+fn extract_barcode_texts(json: &serde_json::Value) -> Vec<String> {
+    // Handles three common Dynamsoft REST response shapes.
+    // Shape 1: {"TextResult":[{"BarcodeText":"..."}]}   (DBR REST server)
+    // Shape 2: {"barcodeResults":[{"text":"..."}]}
+    // Shape 3: {"results":[{"barcodeText":"..."}]}
+    let candidates = [
+        json.get("TextResult")
+            .and_then(|a| a.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|item| item.get("BarcodeText")?.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            }),
+        json.get("barcodeResults")
+            .and_then(|a| a.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|item| item.get("text")?.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            }),
+        json.get("results")
+            .and_then(|a| a.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|item| item.get("barcodeText")?.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            }),
+    ];
+
+    candidates
+        .into_iter()
+        .flatten()
+        .next()
+        .unwrap_or_default()
+}
+
+#[cfg(feature = "dynamsoft")]
+fn scan_qr_dynamsoft(
+    image_bytes: &bytes::Bytes,
+    key: &str,
+    hash_string: &str,
+    license: &str,
+    endpoint: &str,
+    tx: &UnboundedSender<AnalyticsResultSet>,
+    emitted: &mut HashSet<String>,
+) -> anyhow::Result<()> {
+    use base64::Engine as _;
+    let image_b64 =
+        base64::engine::general_purpose::STANDARD.encode(image_bytes.as_ref());
+
+    let payload = serde_json::json!({
+        "imageBase64": image_b64,
+        "licenseKey": license,
+    });
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+
+    let response = client.post(endpoint).json(&payload).send()?;
+
+    if !response.status().is_success() {
+        anyhow::bail!(
+            "Dynamsoft API returned status {}",
+            response.status()
+        );
+    }
+
+    let json: serde_json::Value = response.json()?;
+    let texts = extract_barcode_texts(&json);
+
+    for text in texts {
+        if emitted.insert(text.clone()) {
+            if tx
+                .send(AnalyticsResultSet {
+                    key: key.to_string(),
+                    hash: hash_string.to_string(),
+                    qr_code: text,
+                    qr_quality: "OK".to_string(),
+                    qr_source: "dynamsoft".to_string(),
+                })
+                .is_err()
+            {
+                error!(key, "result channel closed");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Core analytics — runs rxing then (optionally) wechat, union with dedup
 // ---------------------------------------------------------------------------
 
@@ -195,26 +309,11 @@ impl AnalyticsResult {
         image_bytes: bytes::Bytes,
         tx: UnboundedSender<AnalyticsResultSet>,
         _permit: tokio::sync::OwnedSemaphorePermit,
-        _model_path: Arc<Option<PathBuf>>,
+        _config: Arc<AnalyticsConfig>,
     ) {
         let hash_string = hex::encode(Sha256::digest(&image_bytes));
 
-        // Tracks all QR codes emitted for this image — shared across backends
-        // so each unique code is sent exactly once.
-        let mut emitted: HashSet<String> = HashSet::new();
-
-        if let Err(e) = scan_qr_rxing(&image_bytes, &key, &hash_string, &tx, &mut emitted) {
-            warn!(key = key, error = %e, "rxing scan failed");
-        }
-
-        #[cfg(feature = "wechat")]
-        if let Err(e) =
-            scan_qr_wechat(&image_bytes, &key, &hash_string, &_model_path, &tx, &mut emitted)
-        {
-            warn!(key = key, error = %e, "wechat_qrcode scan failed");
-        }
-
-        // EXIF is independent — absence is normal, not an error.
+        // EXIF is always extracted first — independent of QR scanning.
         let mut buf = std::io::BufReader::new(Cursor::new(&image_bytes));
         if let Ok(exif) = exif::Reader::new().read_from_container(&mut buf) {
             for f in exif.fields() {
@@ -229,15 +328,63 @@ impl AnalyticsResult {
                 }
             }
         }
+
+        // Tracks all QR codes emitted for this image — shared across backends
+        // so each unique code is sent exactly once.
+        let mut emitted: HashSet<String> = HashSet::new();
+
+        // Determine whether Dynamsoft-only mode is active.
+        #[cfg(feature = "dynamsoft")]
+        let dynamsoft_only = _config.dynamsoft_only;
+        #[cfg(not(feature = "dynamsoft"))]
+        let dynamsoft_only = false;
+
+        if !dynamsoft_only {
+            if let Err(e) = scan_qr_rxing(&image_bytes, &key, &hash_string, &tx, &mut emitted) {
+                warn!(key = key, error = %e, "rxing scan failed");
+            }
+
+            #[cfg(feature = "wechat")]
+            if let Err(e) = scan_qr_wechat(
+                &image_bytes,
+                &key,
+                &hash_string,
+                &_config.model_path,
+                &tx,
+                &mut emitted,
+            ) {
+                warn!(key = key, error = %e, "wechat_qrcode scan failed");
+            }
+        }
+
+        #[cfg(feature = "dynamsoft")]
+        if let (Some(license), Some(endpoint)) = (
+            _config.dynamsoft_license.as_deref(),
+            _config.dynamsoft_endpoint.as_deref(),
+        ) {
+            if let Err(e) = scan_qr_dynamsoft(
+                &image_bytes,
+                &key,
+                &hash_string,
+                license,
+                endpoint,
+                &tx,
+                &mut emitted,
+            ) {
+                warn!(key = key, error = %e, "dynamsoft scan failed");
+            }
+        } else if _config.dynamsoft_only {
+            warn!(key = key, "dynamsoft_only set but license/endpoint not configured — no scan");
+        }
     }
 
     pub async fn new(
         mut downloadfile_joinset: JoinSet<Result<DownloadFile, RustslingerError>>,
-        model_path: Option<PathBuf>,
+        config: AnalyticsConfig,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         let semaphore = Arc::new(Semaphore::new(num_cpus::get()));
-        let model_path = Arc::new(model_path);
+        let config = Arc::new(config);
 
         tokio::spawn(async move {
             while let Some(join_result) = downloadfile_joinset.join_next().await {
@@ -245,7 +392,7 @@ impl AnalyticsResult {
                     Ok(Ok(file)) => {
                         let tx = tx.clone();
                         let semaphore = semaphore.clone();
-                        let model_path = model_path.clone();
+                        let config = config.clone();
 
                         let permit = match semaphore.acquire_owned().await {
                             Ok(p) => p,
@@ -255,7 +402,7 @@ impl AnalyticsResult {
                         drop(file.permit);
 
                         task::spawn_blocking(move || {
-                            Self::analytics(file.key, file.data, tx, permit, model_path);
+                            Self::analytics(file.key, file.data, tx, permit, config);
                         });
                     }
                     Ok(Err(e)) => warn!(error = %e, "download failed, skipping"),
@@ -285,6 +432,10 @@ mod tests {
     use tokio::sync::Semaphore;
     use tokio::task::JoinSet;
     use crate::{DownloadFile, RustslingerError};
+
+    fn default_config() -> AnalyticsConfig {
+        AnalyticsConfig::default()
+    }
 
     fn make_file(key: &str, data: Vec<u8>) -> DownloadFile {
         let permit = Arc::new(Semaphore::new(1)).try_acquire_owned().unwrap();
@@ -340,7 +491,7 @@ mod tests {
     #[tokio::test]
     async fn empty_joinset_closes_channel() {
         let joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             drain(&mut result),
@@ -361,7 +512,7 @@ mod tests {
                 reason: "not found".to_string(),
             })
         });
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             drain(&mut result),
@@ -375,7 +526,7 @@ mod tests {
     async fn invalid_image_bytes_produce_no_results() {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async { Ok(make_file("corrupt.jpg", vec![0u8; 256])) });
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             drain(&mut result),
@@ -391,7 +542,7 @@ mod tests {
     async fn valid_image_no_qr_no_exif_produces_no_results() {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async { Ok(make_file("blank.png", solid_png())) });
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             drain(&mut result),
@@ -409,7 +560,7 @@ mod tests {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async move { Ok(make_file("qr.png", qr_png(content))) });
 
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(15),
             drain(&mut result),
@@ -436,7 +587,7 @@ mod tests {
         joinset.spawn(async move { Ok(make_file("a.png", d1)) });
         joinset.spawn(async move { Ok(make_file("b.png", d2)) });
 
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(15),
             drain(&mut result),
@@ -487,7 +638,7 @@ mod tests {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async move { Ok(make_file("qr.png", qr_png(content))) });
 
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(15),
             drain(&mut result),
@@ -512,7 +663,7 @@ mod tests {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async { Ok(make_file("blank.png", solid_png())) });
 
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             drain(&mut result),
@@ -528,7 +679,7 @@ mod tests {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async { Ok(make_file("corrupt.jpg", vec![0u8; 256])) });
 
-        let mut result = AnalyticsResult::new(joinset, None).await;
+        let mut result = AnalyticsResult::new(joinset, default_config()).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             drain(&mut result),
@@ -536,5 +687,44 @@ mod tests {
         .await
         .expect("timed out");
         assert!(out.is_empty());
+    }
+
+    // --- dynamsoft feature: extract_barcode_texts covers all response shapes ---
+
+    #[cfg(feature = "dynamsoft")]
+    #[test]
+    fn extract_barcode_texts_dbr_shape() {
+        let json = serde_json::json!({
+            "TextResult": [
+                {"BarcodeText": "hello"},
+                {"BarcodeText": "world"},
+            ]
+        });
+        assert_eq!(extract_barcode_texts(&json), vec!["hello", "world"]);
+    }
+
+    #[cfg(feature = "dynamsoft")]
+    #[test]
+    fn extract_barcode_texts_barcode_results_shape() {
+        let json = serde_json::json!({
+            "barcodeResults": [{"text": "abc"}]
+        });
+        assert_eq!(extract_barcode_texts(&json), vec!["abc"]);
+    }
+
+    #[cfg(feature = "dynamsoft")]
+    #[test]
+    fn extract_barcode_texts_results_shape() {
+        let json = serde_json::json!({
+            "results": [{"barcodeText": "xyz"}]
+        });
+        assert_eq!(extract_barcode_texts(&json), vec!["xyz"]);
+    }
+
+    #[cfg(feature = "dynamsoft")]
+    #[test]
+    fn extract_barcode_texts_unknown_shape_returns_empty() {
+        let json = serde_json::json!({"unknown": "field"});
+        assert!(extract_barcode_texts(&json).is_empty());
     }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5,9 +5,10 @@
 
 use sha2::{Digest, Sha256};
 
+#[cfg(not(feature = "wechat"))]
 use image::io::Reader as ImageReader;
 use std::io::Cursor;
-
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -35,51 +36,147 @@ pub struct AnalyticsResult {
     rx: UnboundedReceiver<AnalyticsResultSet>,
 }
 
+// ---------------------------------------------------------------------------
+// wechat_qrcode path (compiled in only with --features wechat)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "wechat")]
+fn build_wechat_detector(
+    model_path: &Option<PathBuf>,
+) -> anyhow::Result<opencv::wechat_qrcode::WeChatQRCode> {
+    use opencv::wechat_qrcode::WeChatQRCode;
+
+    if let Some(p) = model_path {
+        let dp = p.join("detect.prototxt");
+        let dm = p.join("detect.caffemodel");
+        let sp = p.join("sr.prototxt");
+        let sm = p.join("sr.caffemodel");
+
+        if dp.exists() && dm.exists() && sp.exists() && sm.exists() {
+            return Ok(WeChatQRCode::new(
+                &dp.to_string_lossy(),
+                &dm.to_string_lossy(),
+                &sp.to_string_lossy(),
+                &sm.to_string_lossy(),
+            )?);
+        }
+        warn!(path = ?p, "model files incomplete, falling back to lightweight detector");
+    }
+
+    // Empty strings = built-in lightweight detector (no CNN, similar quality to rqrr)
+    Ok(WeChatQRCode::new("", "", "", "")?)
+}
+
+#[cfg(feature = "wechat")]
+fn scan_qr_wechat(
+    image_bytes: &bytes::Bytes,
+    key: &str,
+    hash_string: &str,
+    model_path: &Option<PathBuf>,
+    tx: &UnboundedSender<AnalyticsResultSet>,
+) -> anyhow::Result<()> {
+    use opencv::prelude::*;
+
+    // Decode image bytes directly with OpenCV — outputs BGR automatically.
+    let buf = opencv::core::Vector::<u8>::from_iter(image_bytes.iter().copied());
+    let mat = opencv::imgcodecs::imdecode(&buf, opencv::imgcodecs::IMREAD_COLOR)?;
+
+    if mat.empty() {
+        anyhow::bail!("OpenCV could not decode image");
+    }
+
+    let mut detector = build_wechat_detector(model_path)?;
+    let mut points = opencv::core::Vector::<opencv::core::Mat>::new();
+    let results = detector.detect_and_decode(&mat, &mut points)?;
+
+    for qr_code in results {
+        if tx
+            .send(AnalyticsResultSet {
+                key: key.to_string(),
+                hash: hash_string.to_string(),
+                qr_code,
+                qr_quality: "OK".to_string(),
+                qr_source: "wechat_qrcode".to_string(),
+            })
+            .is_err()
+        {
+            error!(key, "result channel closed");
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// rqrr path (default, no extra dependencies)
+// ---------------------------------------------------------------------------
+
+#[cfg(not(feature = "wechat"))]
+fn scan_qr_rqrr(
+    image_bytes: &bytes::Bytes,
+    key: &str,
+    hash_string: &str,
+    tx: &UnboundedSender<AnalyticsResultSet>,
+) -> anyhow::Result<()> {
+    let image = ImageReader::new(Cursor::new(image_bytes))
+        .with_guessed_format()?
+        .decode()?;
+
+    let luma = image::imageops::resize(
+        &image.to_luma8(),
+        800,
+        600,
+        image::imageops::FilterType::Nearest,
+    );
+
+    for g in rqrr::PreparedImage::prepare(luma).detect_grids() {
+        let message = match g.decode() {
+            Ok((_, qrcode)) => AnalyticsResultSet {
+                key: key.to_string(),
+                hash: hash_string.to_string(),
+                qr_code: qrcode,
+                qr_quality: "OK".to_string(),
+                qr_source: "rqrr".to_string(),
+            },
+            Err(e) => AnalyticsResultSet {
+                key: key.to_string(),
+                hash: hash_string.to_string(),
+                qr_code: "DECODER_ERROR".to_string(),
+                qr_quality: e.to_string(),
+                qr_source: "rqrr".to_string(),
+            },
+        };
+        if tx.send(message).is_err() {
+            error!(key, "result channel closed");
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Core analytics — dispatches to the active QR backend
+// ---------------------------------------------------------------------------
+
 impl AnalyticsResult {
     fn analytics(
         key: String,
         image_bytes: bytes::Bytes,
         tx: UnboundedSender<AnalyticsResultSet>,
         _permit: tokio::sync::OwnedSemaphorePermit,
+        _model_path: Arc<Option<PathBuf>>,
     ) {
         let hash_string = hex::encode(Sha256::digest(&image_bytes));
 
-        // Use a closure to enable ? for the fallible image decode + QR scan path.
-        let process_qr = || -> anyhow::Result<()> {
-            let image = ImageReader::new(Cursor::new(&image_bytes))
-                .with_guessed_format()?
-                .decode()?;
+        #[cfg(feature = "wechat")]
+        if let Err(e) = scan_qr_wechat(&image_bytes, &key, &hash_string, &_model_path, &tx) {
+            warn!(key = key, error = %e, "skipping QR scan: wechat_qrcode failed");
+        }
 
-            let luma = image::imageops::resize(
-                &image.to_luma8(), 800, 600, image::imageops::FilterType::Nearest,
-            );
-
-            for g in rqrr::PreparedImage::prepare(luma).detect_grids() {
-                let message = match g.decode() {
-                    Ok((_, qrcode)) => AnalyticsResultSet {
-                        key: key.clone(),
-                        hash: hash_string.clone(),
-                        qr_code: qrcode,
-                        qr_quality: "OK".to_string(),
-                        qr_source: "rqrr".to_string(),
-                    },
-                    Err(e) => AnalyticsResultSet {
-                        key: key.clone(),
-                        hash: hash_string.clone(),
-                        qr_code: "DECODER_ERROR".to_string(),
-                        qr_quality: e.to_string(),
-                        qr_source: "rqrr".to_string(),
-                    },
-                };
-                if tx.send(message).is_err() {
-                    error!(key = key, "result channel closed");
-                    return Ok(());
-                }
-            }
-            Ok(())
-        };
-
-        if let Err(e) = process_qr() {
+        #[cfg(not(feature = "wechat"))]
+        if let Err(e) = scan_qr_rqrr(&image_bytes, &key, &hash_string, &tx) {
             warn!(key = key, error = %e, "skipping QR scan: image decode failed");
         }
 
@@ -100,9 +197,13 @@ impl AnalyticsResult {
         }
     }
 
-    pub async fn new(mut downloadfile_joinset: JoinSet<Result<DownloadFile, RustslingerError>>) -> Self {
+    pub async fn new(
+        mut downloadfile_joinset: JoinSet<Result<DownloadFile, RustslingerError>>,
+        model_path: Option<PathBuf>,
+    ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         let semaphore = Arc::new(Semaphore::new(num_cpus::get()));
+        let model_path = Arc::new(model_path);
 
         tokio::spawn(async move {
             while let Some(join_result) = downloadfile_joinset.join_next().await {
@@ -110,6 +211,7 @@ impl AnalyticsResult {
                     Ok(Ok(file)) => {
                         let tx = tx.clone();
                         let semaphore = semaphore.clone();
+                        let model_path = model_path.clone();
 
                         let permit = match semaphore.acquire_owned().await {
                             Ok(p) => p,
@@ -119,7 +221,7 @@ impl AnalyticsResult {
                         drop(file.permit);
 
                         task::spawn_blocking(move || {
-                            Self::analytics(file.key, file.data, tx, permit);
+                            Self::analytics(file.key, file.data, tx, permit, model_path);
                         });
                     }
                     Ok(Err(e)) => warn!(error = %e, "download failed, skipping"),
@@ -136,12 +238,16 @@ impl AnalyticsResult {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
     use std::io::Cursor;
     use std::sync::Arc;
-    use sha2::{Digest, Sha256};
     use tokio::sync::Semaphore;
     use tokio::task::JoinSet;
     use crate::{DownloadFile, RustslingerError};
@@ -190,7 +296,7 @@ mod tests {
     #[tokio::test]
     async fn empty_joinset_closes_channel() {
         let joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
-        let mut result = AnalyticsResult::new(joinset).await;
+        let mut result = AnalyticsResult::new(joinset, None).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             drain(&mut result),
@@ -211,7 +317,7 @@ mod tests {
                 reason: "not found".to_string(),
             })
         });
-        let mut result = AnalyticsResult::new(joinset).await;
+        let mut result = AnalyticsResult::new(joinset, None).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             drain(&mut result),
@@ -227,7 +333,7 @@ mod tests {
     async fn invalid_image_bytes_produce_no_results() {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async { Ok(make_file("corrupt.jpg", vec![0u8; 256])) });
-        let mut result = AnalyticsResult::new(joinset).await;
+        let mut result = AnalyticsResult::new(joinset, None).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             drain(&mut result),
@@ -243,7 +349,7 @@ mod tests {
     async fn valid_image_no_qr_no_exif_produces_no_results() {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async { Ok(make_file("blank.png", solid_png())) });
-        let mut result = AnalyticsResult::new(joinset).await;
+        let mut result = AnalyticsResult::new(joinset, None).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             drain(&mut result),
@@ -260,9 +366,6 @@ mod tests {
         let data = solid_png();
         let expected_hash = hex::encode(Sha256::digest(&data));
 
-        let joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
-        // Inject a file that would produce a result by sending one directly through
-        // the channel, bypassing the analytics path — test the struct fields only.
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         tx.send(AnalyticsResultSet {
             key: "test/photo.jpg".to_string(),
@@ -274,8 +377,6 @@ mod tests {
         .unwrap();
         drop(tx);
 
-        // Drain the receiver directly without going through the pipeline.
-        let _ = joinset; // unused but keeps type inference happy
         let mut mock_result = AnalyticsResult { rx };
         let out = drain(&mut mock_result).await;
 
@@ -283,5 +384,70 @@ mod tests {
         assert_eq!(out[0].key, "test/photo.jpg");
         assert_eq!(out[0].hash, expected_hash);
         assert_eq!(out[0].qr_source, "rqrr");
+    }
+
+    // --- wechat_qrcode path (only compiled with --features wechat) ---
+
+    #[cfg(feature = "wechat")]
+    fn qr_png(content: &str) -> Vec<u8> {
+        use qrcode::QrCode;
+        let code = QrCode::new(content.as_bytes()).unwrap();
+        let img = code.render::<image::Luma<u8>>().build();
+        let dynamic = image::DynamicImage::ImageLuma8(img);
+        let mut buf = Cursor::new(Vec::new());
+        dynamic.write_to(&mut buf, image::ImageOutputFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
+    #[cfg(feature = "wechat")]
+    #[tokio::test]
+    async fn wechat_detects_qr_code() {
+        let content = "https://github.com/tke1973/rustslinger";
+        let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
+        joinset.spawn(async move { Ok(make_file("qr.png", qr_png(content))) });
+
+        let mut result = AnalyticsResult::new(joinset, None).await;
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            drain(&mut result),
+        )
+        .await
+        .expect("timed out");
+
+        assert!(!out.is_empty(), "wechat_qrcode should have detected the QR code");
+        assert_eq!(out[0].qr_code, content);
+        assert_eq!(out[0].qr_source, "wechat_qrcode");
+    }
+
+    #[cfg(feature = "wechat")]
+    #[tokio::test]
+    async fn wechat_handles_invalid_image_gracefully() {
+        let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
+        joinset.spawn(async { Ok(make_file("corrupt.jpg", vec![0u8; 256])) });
+
+        let mut result = AnalyticsResult::new(joinset, None).await;
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            drain(&mut result),
+        )
+        .await
+        .expect("timed out");
+        assert!(out.is_empty());
+    }
+
+    #[cfg(feature = "wechat")]
+    #[tokio::test]
+    async fn wechat_blank_image_produces_no_results() {
+        let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
+        joinset.spawn(async { Ok(make_file("blank.png", solid_png())) });
+
+        let mut result = AnalyticsResult::new(joinset, None).await;
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            drain(&mut result),
+        )
+        .await
+        .expect("timed out");
+        assert!(out.is_empty());
     }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5,8 +5,7 @@
 
 use sha2::{Digest, Sha256};
 
-#[cfg(not(feature = "wechat"))]
-use image::io::Reader as ImageReader;
+use std::collections::HashSet;
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -37,7 +36,83 @@ pub struct AnalyticsResult {
 }
 
 // ---------------------------------------------------------------------------
-// wechat_qrcode path (compiled in only with --features wechat)
+// Image preparation — proportional downscale only, Lanczos3
+// ---------------------------------------------------------------------------
+
+fn prepare_luma(image: &image::DynamicImage) -> image::GrayImage {
+    let luma = image.to_luma8();
+    let (w, h) = (luma.width(), luma.height());
+    const MAX_DIM: u32 = 4000;
+    if w > MAX_DIM || h > MAX_DIM {
+        let scale = MAX_DIM as f32 / w.max(h) as f32;
+        image::imageops::resize(
+            &luma,
+            (w as f32 * scale) as u32,
+            (h as f32 * scale) as u32,
+            image::imageops::FilterType::Lanczos3,
+        )
+    } else {
+        luma
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rxing backend — pure Rust, always active
+// ---------------------------------------------------------------------------
+
+fn scan_qr_rxing(
+    image_bytes: &bytes::Bytes,
+    key: &str,
+    hash_string: &str,
+    tx: &UnboundedSender<AnalyticsResultSet>,
+    emitted: &mut HashSet<String>,
+) -> anyhow::Result<()> {
+    let image = image::load_from_memory(image_bytes)
+        .map_err(|e| anyhow::anyhow!("image decode: {}", e))?;
+
+    let luma = prepare_luma(&image);
+    let (width, height) = (luma.width(), luma.height());
+
+    let mut hints = rxing::DecodeHints::default();
+    hints.TryHarder = Some(true);
+
+    let results = match rxing::helpers::detect_multiple_in_luma_with_hints(
+        luma.into_raw(),
+        width,
+        height,
+        &mut hints,
+    ) {
+        Ok(r) => r,
+        // NotFoundException means no barcodes found — not an error condition.
+        Err(rxing::Exceptions::NotFoundException(_)) => return Ok(()),
+        Err(e) => return Err(anyhow::anyhow!("rxing: {}", e)),
+    };
+
+    for result in results {
+        let text = result.getText().to_string();
+        if emitted.insert(text.clone()) {
+            if tx
+                .send(AnalyticsResultSet {
+                    key: key.to_string(),
+                    hash: hash_string.to_string(),
+                    qr_code: text,
+                    qr_quality: "OK".to_string(),
+                    qr_source: "rxing".to_string(),
+                })
+                .is_err()
+            {
+                error!(key, "result channel closed");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// wechat_qrcode backend — OpenCV, compiled in with --features wechat
+// Runs after rxing; only emits codes not already found by rxing.
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "wechat")]
@@ -63,7 +138,6 @@ fn build_wechat_detector(
         warn!(path = ?p, "model files incomplete, falling back to lightweight detector");
     }
 
-    // Empty strings = built-in lightweight detector (no CNN, similar quality to rqrr)
     Ok(WeChatQRCode::new("", "", "", "")?)
 }
 
@@ -74,10 +148,10 @@ fn scan_qr_wechat(
     hash_string: &str,
     model_path: &Option<PathBuf>,
     tx: &UnboundedSender<AnalyticsResultSet>,
+    emitted: &mut HashSet<String>,
 ) -> anyhow::Result<()> {
     use opencv::prelude::*;
 
-    // Decode image bytes directly with OpenCV — outputs BGR automatically.
     let buf = opencv::core::Vector::<u8>::from_iter(image_bytes.iter().copied());
     let mat = opencv::imgcodecs::imdecode(&buf, opencv::imgcodecs::IMREAD_COLOR)?;
 
@@ -90,18 +164,21 @@ fn scan_qr_wechat(
     let results = detector.detect_and_decode(&mat, &mut points)?;
 
     for qr_code in results {
-        if tx
-            .send(AnalyticsResultSet {
-                key: key.to_string(),
-                hash: hash_string.to_string(),
-                qr_code,
-                qr_quality: "OK".to_string(),
-                qr_source: "wechat_qrcode".to_string(),
-            })
-            .is_err()
-        {
-            error!(key, "result channel closed");
-            break;
+        // Only emit codes not already found by rxing.
+        if emitted.insert(qr_code.clone()) {
+            if tx
+                .send(AnalyticsResultSet {
+                    key: key.to_string(),
+                    hash: hash_string.to_string(),
+                    qr_code,
+                    qr_quality: "OK".to_string(),
+                    qr_source: "wechat_qrcode".to_string(),
+                })
+                .is_err()
+            {
+                error!(key, "result channel closed");
+                break;
+            }
         }
     }
 
@@ -109,55 +186,7 @@ fn scan_qr_wechat(
 }
 
 // ---------------------------------------------------------------------------
-// rqrr path (default, no extra dependencies)
-// ---------------------------------------------------------------------------
-
-#[cfg(not(feature = "wechat"))]
-fn scan_qr_rqrr(
-    image_bytes: &bytes::Bytes,
-    key: &str,
-    hash_string: &str,
-    tx: &UnboundedSender<AnalyticsResultSet>,
-) -> anyhow::Result<()> {
-    let image = ImageReader::new(Cursor::new(image_bytes))
-        .with_guessed_format()?
-        .decode()?;
-
-    let luma = image::imageops::resize(
-        &image.to_luma8(),
-        800,
-        600,
-        image::imageops::FilterType::Nearest,
-    );
-
-    for g in rqrr::PreparedImage::prepare(luma).detect_grids() {
-        let message = match g.decode() {
-            Ok((_, qrcode)) => AnalyticsResultSet {
-                key: key.to_string(),
-                hash: hash_string.to_string(),
-                qr_code: qrcode,
-                qr_quality: "OK".to_string(),
-                qr_source: "rqrr".to_string(),
-            },
-            Err(e) => AnalyticsResultSet {
-                key: key.to_string(),
-                hash: hash_string.to_string(),
-                qr_code: "DECODER_ERROR".to_string(),
-                qr_quality: e.to_string(),
-                qr_source: "rqrr".to_string(),
-            },
-        };
-        if tx.send(message).is_err() {
-            error!(key, "result channel closed");
-            return Ok(());
-        }
-    }
-
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Core analytics — dispatches to the active QR backend
+// Core analytics — runs rxing then (optionally) wechat, union with dedup
 // ---------------------------------------------------------------------------
 
 impl AnalyticsResult {
@@ -170,14 +199,19 @@ impl AnalyticsResult {
     ) {
         let hash_string = hex::encode(Sha256::digest(&image_bytes));
 
-        #[cfg(feature = "wechat")]
-        if let Err(e) = scan_qr_wechat(&image_bytes, &key, &hash_string, &_model_path, &tx) {
-            warn!(key = key, error = %e, "skipping QR scan: wechat_qrcode failed");
+        // Tracks all QR codes emitted for this image — shared across backends
+        // so each unique code is sent exactly once.
+        let mut emitted: HashSet<String> = HashSet::new();
+
+        if let Err(e) = scan_qr_rxing(&image_bytes, &key, &hash_string, &tx, &mut emitted) {
+            warn!(key = key, error = %e, "rxing scan failed");
         }
 
-        #[cfg(not(feature = "wechat"))]
-        if let Err(e) = scan_qr_rqrr(&image_bytes, &key, &hash_string, &tx) {
-            warn!(key = key, error = %e, "skipping QR scan: image decode failed");
+        #[cfg(feature = "wechat")]
+        if let Err(e) =
+            scan_qr_wechat(&image_bytes, &key, &hash_string, &_model_path, &tx, &mut emitted)
+        {
+            warn!(key = key, error = %e, "wechat_qrcode scan failed");
         }
 
         // EXIF is independent — absence is normal, not an error.
@@ -268,6 +302,16 @@ mod tests {
         buf.into_inner()
     }
 
+    fn qr_png(content: &str) -> Vec<u8> {
+        use qrcode::QrCode;
+        let code = QrCode::new(content.as_bytes()).unwrap();
+        let img = code.render::<image::Luma<u8>>().build();
+        let dynamic = image::DynamicImage::ImageLuma8(img);
+        let mut buf = Cursor::new(Vec::new());
+        dynamic.write_to(&mut buf, image::ImageOutputFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
     async fn drain(result: &mut AnalyticsResult) -> Vec<AnalyticsResultSet> {
         let mut out = Vec::new();
         while let Some(r) = result.get_next().await {
@@ -302,11 +346,11 @@ mod tests {
             drain(&mut result),
         )
         .await
-        .expect("timed out waiting for empty joinset to close channel");
+        .expect("timed out");
         assert!(out.is_empty());
     }
 
-    // --- pipeline: download error is skipped gracefully ---
+    // --- pipeline: error handling ---
 
     #[tokio::test]
     async fn download_error_produces_no_results() {
@@ -327,8 +371,6 @@ mod tests {
         assert!(out.is_empty());
     }
 
-    // --- pipeline: invalid bytes are skipped gracefully ---
-
     #[tokio::test]
     async fn invalid_image_bytes_produce_no_results() {
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
@@ -343,7 +385,7 @@ mod tests {
         assert!(out.is_empty());
     }
 
-    // --- pipeline: valid image with no QR and no EXIF ---
+    // --- pipeline: valid image, no QR ---
 
     #[tokio::test]
     async fn valid_image_no_qr_no_exif_produces_no_results() {
@@ -359,49 +401,10 @@ mod tests {
         assert!(out.is_empty());
     }
 
-    // --- pipeline: result fields are populated correctly ---
+    // --- rxing: detects a single QR code ---
 
     #[tokio::test]
-    async fn result_key_and_hash_are_correct() {
-        let data = solid_png();
-        let expected_hash = hex::encode(Sha256::digest(&data));
-
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        tx.send(AnalyticsResultSet {
-            key: "test/photo.jpg".to_string(),
-            hash: expected_hash.clone(),
-            qr_code: "https://example.com".to_string(),
-            qr_quality: "OK".to_string(),
-            qr_source: "rqrr".to_string(),
-        })
-        .unwrap();
-        drop(tx);
-
-        let mut mock_result = AnalyticsResult { rx };
-        let out = drain(&mut mock_result).await;
-
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].key, "test/photo.jpg");
-        assert_eq!(out[0].hash, expected_hash);
-        assert_eq!(out[0].qr_source, "rqrr");
-    }
-
-    // --- wechat_qrcode path (only compiled with --features wechat) ---
-
-    #[cfg(feature = "wechat")]
-    fn qr_png(content: &str) -> Vec<u8> {
-        use qrcode::QrCode;
-        let code = QrCode::new(content.as_bytes()).unwrap();
-        let img = code.render::<image::Luma<u8>>().build();
-        let dynamic = image::DynamicImage::ImageLuma8(img);
-        let mut buf = Cursor::new(Vec::new());
-        dynamic.write_to(&mut buf, image::ImageOutputFormat::Png).unwrap();
-        buf.into_inner()
-    }
-
-    #[cfg(feature = "wechat")]
-    #[tokio::test]
-    async fn wechat_detects_qr_code() {
+    async fn rxing_detects_single_qr_code() {
         let content = "https://github.com/tke1973/rustslinger";
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
         joinset.spawn(async move { Ok(make_file("qr.png", qr_png(content))) });
@@ -414,25 +417,93 @@ mod tests {
         .await
         .expect("timed out");
 
-        assert!(!out.is_empty(), "wechat_qrcode should have detected the QR code");
+        assert_eq!(out.len(), 1);
         assert_eq!(out[0].qr_code, content);
-        assert_eq!(out[0].qr_source, "wechat_qrcode");
+        assert_eq!(out[0].qr_source, "rxing");
     }
 
-    #[cfg(feature = "wechat")]
+    // --- rxing: each unique QR code emitted exactly once ---
+
     #[tokio::test]
-    async fn wechat_handles_invalid_image_gracefully() {
+    async fn rxing_each_qr_code_emitted_once() {
+        // Feed the same image twice — two files, same QR content.
+        // Each file is independent so each should emit one result.
+        let content = "dedup-test";
+        let data = qr_png(content);
         let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
-        joinset.spawn(async { Ok(make_file("corrupt.jpg", vec![0u8; 256])) });
+        let d1 = data.clone();
+        let d2 = data.clone();
+        joinset.spawn(async move { Ok(make_file("a.png", d1)) });
+        joinset.spawn(async move { Ok(make_file("b.png", d2)) });
 
         let mut result = AnalyticsResult::new(joinset, None).await;
         let out = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            std::time::Duration::from_secs(15),
             drain(&mut result),
         )
         .await
         .expect("timed out");
-        assert!(out.is_empty());
+
+        // Two files → two results (dedup is per-image, not global)
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|r| r.qr_code == content));
+    }
+
+    // --- result fields ---
+
+    #[tokio::test]
+    async fn result_key_and_hash_are_correct() {
+        let data = solid_png();
+        let expected_hash = hex::encode(Sha256::digest(&data));
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        tx.send(AnalyticsResultSet {
+            key: "test/photo.jpg".to_string(),
+            hash: expected_hash.clone(),
+            qr_code: "https://example.com".to_string(),
+            qr_quality: "OK".to_string(),
+            qr_source: "rxing".to_string(),
+        })
+        .unwrap();
+        drop(tx);
+
+        let mut mock_result = AnalyticsResult { rx };
+        let out = drain(&mut mock_result).await;
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].key, "test/photo.jpg");
+        assert_eq!(out[0].hash, expected_hash);
+        assert_eq!(out[0].qr_source, "rxing");
+    }
+
+    // --- wechat feature: dual-backend union ---
+
+    #[cfg(feature = "wechat")]
+    #[tokio::test]
+    async fn dual_backend_detects_qr_code() {
+        // Both rxing and wechat run. The QR code should appear exactly once
+        // regardless of which backend finds it first.
+        let content = "https://github.com/tke1973/rustslinger";
+        let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
+        joinset.spawn(async move { Ok(make_file("qr.png", qr_png(content))) });
+
+        let mut result = AnalyticsResult::new(joinset, None).await;
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            drain(&mut result),
+        )
+        .await
+        .expect("timed out");
+
+        // Exactly one result — dedup prevents double-emission.
+        assert_eq!(out.len(), 1, "same QR code must not be emitted twice");
+        assert_eq!(out[0].qr_code, content);
+        // Source is whichever backend found it first (rxing runs first).
+        assert!(
+            out[0].qr_source == "rxing" || out[0].qr_source == "wechat_qrcode",
+            "unexpected source: {}",
+            out[0].qr_source
+        );
     }
 
     #[cfg(feature = "wechat")]
@@ -444,6 +515,22 @@ mod tests {
         let mut result = AnalyticsResult::new(joinset, None).await;
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(10),
+            drain(&mut result),
+        )
+        .await
+        .expect("timed out");
+        assert!(out.is_empty());
+    }
+
+    #[cfg(feature = "wechat")]
+    #[tokio::test]
+    async fn wechat_handles_invalid_image_gracefully() {
+        let mut joinset: JoinSet<Result<DownloadFile, RustslingerError>> = JoinSet::new();
+        joinset.spawn(async { Ok(make_file("corrupt.jpg", vec![0u8; 256])) });
+
+        let mut result = AnalyticsResult::new(joinset, None).await;
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
             drain(&mut result),
         )
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Result};
 use clap::Parser;
 
 use std::env;
+use std::path::PathBuf;
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_config::profile::credentials::ProfileFileCredentialsProvider;
@@ -42,6 +43,13 @@ struct Args {
     /// aws s3 bucket list
     #[arg(short = 'l', long, required = false)]
     bucketlist: bool,
+
+    /// Path to directory containing wechat_qrcode model files:
+    /// detect.prototxt, detect.caffemodel, sr.prototxt, sr.caffemodel.
+    /// Only used when built with --features wechat. Falls back to the
+    /// lightweight built-in detector if files are absent.
+    #[arg(short = 'm', long, required = false)]
+    model_path: Option<PathBuf>,
 }
 
 async fn list_s3buckets(client: &Client) -> Result<(), RustslingerError> {
@@ -104,7 +112,7 @@ async fn main() -> Result<()> {
     let handle_data = crate::download::download_files_tasker(client.clone(), &args.bucket).await;
 
     println!("Analyzing files.");
-    let mut analysis_results = AnalyticsResult::new(handle_data).await;
+    let mut analysis_results = AnalyticsResult::new(handle_data, args.model_path).await;
 
     println!("Waiting for results.");
     let mut rc: u128 = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ mod download;
 pub use crate::download::DownloadFile;
 
 mod analysis;
-pub use crate::analysis::{AnalyticsResult, AnalyticsResultSet};
+pub use crate::analysis::{AnalyticsConfig, AnalyticsResult, AnalyticsResultSet};
 
 /// rustslinger
 ///
@@ -50,6 +50,24 @@ struct Args {
     /// lightweight built-in detector if files are absent.
     #[arg(short = 'm', long, required = false)]
     model_path: Option<PathBuf>,
+
+    /// Dynamsoft Barcode Reader license key.
+    /// Only used when built with --features dynamsoft.
+    #[cfg(feature = "dynamsoft")]
+    #[arg(long, required = false)]
+    dynamsoft_license: Option<String>,
+
+    /// Dynamsoft REST API endpoint URL (e.g. http://localhost:18622/api/dbr/read).
+    /// Only used when built with --features dynamsoft.
+    #[cfg(feature = "dynamsoft")]
+    #[arg(long, required = false)]
+    dynamsoft_endpoint: Option<String>,
+
+    /// Skip rxing and wechat — use Dynamsoft as the only QR/barcode backend.
+    /// Only used when built with --features dynamsoft.
+    #[cfg(feature = "dynamsoft")]
+    #[arg(long, required = false)]
+    dynamsoft_only: bool,
 }
 
 async fn list_s3buckets(client: &Client) -> Result<(), RustslingerError> {
@@ -112,7 +130,16 @@ async fn main() -> Result<()> {
     let handle_data = crate::download::download_files_tasker(client.clone(), &args.bucket).await;
 
     println!("Analyzing files.");
-    let mut analysis_results = AnalyticsResult::new(handle_data, args.model_path).await;
+    let config = AnalyticsConfig {
+        model_path: args.model_path,
+        #[cfg(feature = "dynamsoft")]
+        dynamsoft_license: args.dynamsoft_license,
+        #[cfg(feature = "dynamsoft")]
+        dynamsoft_endpoint: args.dynamsoft_endpoint,
+        #[cfg(feature = "dynamsoft")]
+        dynamsoft_only: args.dynamsoft_only,
+    };
+    let mut analysis_results = AnalyticsResult::new(handle_data, config).await;
 
     println!("Waiting for results.");
     let mut rc: u128 = 0;


### PR DESCRIPTION
## Summary

- Introduces `AnalyticsConfig` struct to carry all per-run settings (`model_path`, Dynamsoft fields), replacing the bare `Option<PathBuf>` passed through the pipeline
- Adds `--features dynamsoft` feature flag pulling in `reqwest 0.11` (blocking + JSON), `serde_json`, and `base64`
- Implements `scan_qr_dynamsoft()`: POSTs a base64-encoded image to a configurable Dynamsoft Barcode Reader REST endpoint, parses results across three common Dynamsoft JSON response shapes, and deduplicates against the shared per-image `emitted` `HashSet`
- Dispatch supports two modes:
  - **Third-pass** (default): Dynamsoft runs after rxing + wechat, contributing only codes not already found
  - **Dynamsoft-only** (`--dynamsoft-only`): skip rxing and wechat entirely
- EXIF `UserComment` extraction moved to the very first step in `analytics()`, before any QR scanning
- Adds `--dynamsoft-license`, `--dynamsoft-endpoint`, `--dynamsoft-only` CLI args (all `#[cfg(feature = "dynamsoft")]`-gated)
- 4 new unit tests for `extract_barcode_texts` covering all three Dynamsoft response shapes plus the unknown-shape fallback

## Test plan

- [ ] `cargo build --release` — clean, zero warnings
- [ ] `cargo test` — 12/12 pass (default feature set)
- [ ] `cargo test --features dynamsoft` — 16/16 pass (includes 4 new Dynamsoft JSON parsing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)